### PR TITLE
Added Security Newsletter to 'Keeping Informed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ There are a variety of initiatives underway to migrate security and compliance i
 We've discovered a treasure trove of mailing lists and newsletters where DevSecOps like us are sharing their skills and insights.  
 
 * [Ruby Weekly](http://rubyweekly.com)
+* [Security Newsletter](https://securitynewsletter.co/)
 
 ## Wardley Maps for Security
 One way for people to continue to evolve their capabilities and share common understanding is through the development of Wardley Maps.  We're collecting this information and providing some good examples here.


### PR DESCRIPTION
It's essentially self-promotion, since I write the newsletter in question. But dev(sec)ops do make up most of the subscriber base, which is what I aim for. 

If you find this valid, I'd love the addition. If not, no worries :-)