### PR TITLE
Added Docker Security - Quick Ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A small collection of DevOps and Security podcasts.
 
 ## Books
 Books focussed around DevSecOps, bringing the security focus up front.
+* [Docker Securitiy - Quick Reference](https://binarymist.io/publication/docker-security/)
 * [Holistic Info-Sec for Web Developers](https://leanpub.com/b/holisticinfosecforwebdevelopers)
 
 # Tools


### PR DESCRIPTION
The security defaults of Docker are established to get you up and running ("just work") quickly, rather than being the most secure. There are many default configurations that can be improved upon. This book will help you do just that.