### PR TITLE
docs(guidelines): add DevSecOps Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ While we're not into the paper-way of doing things, sharing sound advice and goo
 * [Security Guide for Web Developers](https://github.com/FallibleInc/security-guide-for-developers)
 * [A practical guide to build DAST with OWASP Zap](https://github.com/Soluto/owasp-zap-glue-ci-images)
 * [Introduction to security testing and tools](https://www.omerlh.info/2018/10/04/write-good-code-with-security-tests/)
+* [DevSecOps Hub](https://snyk.io/devsecops/)
 
 
 ## Presentations


### PR DESCRIPTION
Add a link to [DevSecOps Hub](https://snyk.io/devsecops) 