### PR TITLE
Added Roadmap link of DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This list will not be fully comprehensive and will change as DevSecOps matures. 
   - [Initiatives](#initiatives)
   - [Keeping Informed](#keeping-informed)
   - [Wardley Maps for Security](#wardley-maps-for-security)
+  - [Roadmaps](#roadmaps)
 - [Training](#training)
   - [Labs](#labs)
   - [Vulnerable Test Targets](#vulnerable-test-targets)
@@ -89,6 +90,12 @@ One way for people to continue to evolve their capabilities and share common und
 * [Introduction to Wardley Maps](http://blog.gardeviance.org/2015/02/an-introduction-to-wardley-value-chain.html)
 * [Security Industry Example](http://blog.gardeviance.org/2014_08_01_archive.html)
 * [SOC Value Chain & Delivery Models](http://blog.blackswansecurity.com/2016/01/soc-value-chain-delivery-models/)
+
+
+## Roadmaps
+A roadmap outlines the steps and objectives for implementing best practices to improve collaboration, efficiency, and faster software delivery in an organization. It helps to define goals, prioritize initiatives, allocate resources, and measure progress towards a desired output.
+
+* [DevOps Roadmap](https://roadmap.sh/devops)
 
 
 # Training


### PR DESCRIPTION
Hi Slietz,

I came across your repository [awesome-devsecops](https://github.com/devsecops/awesome-devsecops) and found it to be a valuable resource for DevOps enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["DevOps Roadmap"](https://roadmap.sh/devops). I took the initiative to submit a ["Pull Request"](https://github.com/devsecops/awesome-devsecops/pull/77) adding it in Information section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz