### PR TITLE
Add WAFtester to Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Testing is an essential element of a DevSecOps program because it helps to prepa
 * [ShiftLeft Scan](https://slscan.io)
 * [Snyk](https://snyk.io)
 * [SourceClear](https://www.sourceclear.com)
+* [WAFtester](https://github.com/waftester/waftester) - WAF security testing CLI with 2800+ attack payloads, 197+ WAF vendor detection, bypass discovery with 70+ evasion techniques, and CI/CD integration via SARIF/SonarQube/GitLab SAST output.
 
 
 ## Alerting


### PR DESCRIPTION
Adds [WAFtester](https://github.com/waftester/waftester) to the Testing section.

**WAFtester** is an open-source WAF security testing CLI that:
- Tests WAF rule coverage with 2800+ attack payloads across 18 categories
- Fingerprints 197+ WAF vendors
- Automates bypass discovery with 70+ evasion techniques
- Outputs SARIF, SonarQube, GitLab SAST, and JUnit for CI/CD integration
- Quantitative scoring (F1, MCC, FPR) for WAF effectiveness measurement

It fits the DevSecOps pipeline as a testing tool that can run in CI/CD to validate WAF configurations before and after deployment.

GitHub: https://github.com/waftester/waftester